### PR TITLE
Use one tool for reading items instead of a tool per collection

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,23 @@ Then configure Claude AI to use the `npm` package as remote server:
 
 ### Read Items
 
-Read items from a collection. The MCP server will automatically generate one tool per collection. It currently accepts `fields`, `sort`, and `limit` as parameters
+The `read-items` tool allows you to read items from any Directus collection by providing the collection name as a parameter.
+
+Parameters:
+- `collection`: (required) The name of the collection to read from
+- `fields`: (optional) Array of field names to return
+- `sort`: (optional) Field to sort by (prefix with `-` for descending order)
+- `limit`: (optional) Maximum number of items to return
+
+Example:
+```json
+{
+  "collection": "articles",
+  "fields": ["id", "title", "date_published"],
+  "sort": "-date_published",
+  "limit": 10
+}
+```
 
 ### Read Current User
 
@@ -58,7 +74,7 @@ Get information about the current user. Effectively the `/users/me` endpoint.
 
 ### Read Collections
 
-Return what collections/fields are available in the system
+Return what collections/fields are available in the system. Use this tool first to discover available collections before using the `read-items` tool.
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ async function main() {
 	const config = createConfig();
 	const directus = createDirectus(config);
 	const schema = await fetchSchema(directus);
-	const tools = getTools(schema);
+	const tools = getTools();
 
 	const server = new Server(
 		{

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,11 +1,11 @@
 import type { Schema } from "../types/schema.js";
 import type { ToolDefinition } from "../types/tool.js";
 import collections from "./collections.js";
-import { createItemTools } from "./items.js";
+import { genericReadItemsTool } from "./items.js";
 import usersMe from "./users/me.js";
 
-const staticTools: ToolDefinition[] = [usersMe, collections];
+const tools: ToolDefinition[] = [usersMe, collections, genericReadItemsTool];
 
-export const getTools = (schema: Schema) => {
-	return [...staticTools, ...createItemTools(schema)];
+export const getTools = (_schema: Schema) => {
+	return tools;
 };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,11 +1,14 @@
-import type { Schema } from "../types/schema.js";
 import type { ToolDefinition } from "../types/tool.js";
 import collections from "./collections.js";
-import { genericReadItemsTool } from "./items.js";
+import { createGenericReadItemsTool } from "./items.js";
 import usersMe from "./users/me.js";
 
-const tools: ToolDefinition[] = [usersMe, collections, genericReadItemsTool];
-
-export const getTools = (_schema: Schema) => {
-	return tools;
+export const getTools = () => {
+	const genericReadItemsTool = createGenericReadItemsTool();
+	const staticTools: ToolDefinition[] = [
+		usersMe,
+		collections,
+		genericReadItemsTool,
+	];
+	return staticTools;
 };

--- a/src/tools/items.ts
+++ b/src/tools/items.ts
@@ -1,18 +1,88 @@
-import { readItems } from '@directus/sdk'
-import * as z from 'zod'
-import { defineTool } from '../utils/define-tool.js'
+import { readItems } from "@directus/sdk";
+import * as z from "zod";
+import type { Schema } from "../types/schema.js";
+import { defineTool } from "../utils/define-tool.js";
 
-export const genericReadItemsTool = defineTool('read-items', {
-	description: 'Read items from any collection by providing the collection name',
-	inputSchema: z.object({
-		collection: z.string().describe('The name of the collection to read from'),
-		fields: z.array(z.string()).optional().describe('Fields to return'),
-		sort: z.string().optional().describe('Field to sort by (prefix with - for descending)'),
-		limit: z.number().optional().describe('Maximum number of items to return')
-	}),
-	handler: async (directus, query) => {
-		const { collection, ...params } = query
-		const items = await directus.request(readItems(collection, params))
-		return { content: [{ type: 'text', text: JSON.stringify(items) }] }
-	}
-})
+export const createGenericReadItemsTool = () => {
+	return defineTool("read-items", {
+		description:
+			"Read items from any collection. Fields and sort options are validated against the schema.",
+		inputSchema: z.object({
+			collection: z
+				.string()
+				.describe("The name of the collection to read from"),
+			fields: z.array(z.string()).optional().describe("Fields to return"),
+			sort: z
+				.string()
+				.optional()
+				.describe("Field to sort by (prefix with - for descending)"),
+			limit: z
+				.number()
+				.optional()
+				.describe("Maximum number of items to return"),
+		}),
+		handler: async (directus, query, { schema: contextSchema }) => {
+			const { collection, fields, sort, ...otherParams } = query;
+
+			try {
+				if (!contextSchema[collection]) {
+					throw new Error(
+						`Collection "${collection}" not found. Use read-collections tool first.`,
+					);
+				}
+
+				const availableFields = contextSchema[collection] || [];
+
+				if (fields && fields.length > 0) {
+					const invalidFields = fields.filter(
+						(field: string) => !availableFields.includes(field),
+					);
+					if (invalidFields.length > 0) {
+						throw new Error(
+							`Invalid fields for "${collection}": ${invalidFields.join(", ")}`,
+						);
+					}
+				}
+
+				if (sort) {
+					const sortField = sort.startsWith("-") ? sort.substring(1) : sort;
+					if (!availableFields.includes(sortField)) {
+						throw new Error(
+							`Invalid sort field "${sortField}" for collection "${collection}"`,
+						);
+					}
+				}
+
+				const params: Record<string, any> = { ...otherParams };
+
+				if (fields && fields.length > 0) {
+					params["fields"] = fields;
+				}
+
+				if (sort) {
+					params["sort"] = sort;
+				}
+
+				const items = await directus.request(readItems(collection, params));
+				return { content: [{ type: "text", text: JSON.stringify(items) }] };
+			} catch (error: any) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: JSON.stringify({
+								error: `Error: ${error?.message || "Unknown error"}`,
+							}),
+						},
+					],
+				};
+			}
+		},
+	});
+};
+
+export const getCollectionSchema = (schema: Schema, collection: string) => {
+	const fields = schema[collection] || [];
+	const description = `Collection "${collection}" has these fields: ${fields.join(", ")}`;
+	return { fields, description };
+};

--- a/src/tools/items.ts
+++ b/src/tools/items.ts
@@ -1,48 +1,18 @@
-import { readItems } from "@directus/sdk";
-import * as z from "zod";
-import type { Schema } from "../types/schema.js";
-import type { ToolDefinition } from "../types/tool.js";
-import { defineTool } from "../utils/define-tool.js";
+import { readItems } from '@directus/sdk'
+import * as z from 'zod'
+import { defineTool } from '../utils/define-tool.js'
 
-const createInputSchema = (input: string[]) => {
-	if (input.length === 0) {
-		return z.object({});
+export const genericReadItemsTool = defineTool('read-items', {
+	description: 'Read items from any collection by providing the collection name',
+	inputSchema: z.object({
+		collection: z.string().describe('The name of the collection to read from'),
+		fields: z.array(z.string()).optional().describe('Fields to return'),
+		sort: z.string().optional().describe('Field to sort by (prefix with - for descending)'),
+		limit: z.number().optional().describe('Maximum number of items to return')
+	}),
+	handler: async (directus, query) => {
+		const { collection, ...params } = query
+		const items = await directus.request(readItems(collection, params))
+		return { content: [{ type: 'text', text: JSON.stringify(items) }] }
 	}
-
-	if (input.length === 1) {
-		const field = input[0] as string;
-
-		return z.object({
-			fields: z.array(z.literal(field)),
-			sort: z.enum([field, `-${field}`]),
-			limit: z.number(),
-		});
-	}
-
-	const fields = input as [string, ...string[]];
-
-	return z.object({
-		fields: z.array(z.enum(fields)),
-		sort: z.enum([...fields, ...fields.map((f) => `-${f}`)]),
-		limit: z.number(),
-	});
-};
-
-export const createItemTools = (schema: Schema) => {
-	const tools: ToolDefinition[] = [];
-
-	for (const [collection, fields] of Object.entries(schema)) {
-		tools.push(
-			defineTool(`read-${collection.toLowerCase()}`, {
-				description: `Read items from the "${collection}" collection`,
-				inputSchema: createInputSchema(fields),
-				handler: async (directus, query) => {
-					const items = await directus.request(readItems(collection, query));
-					return { content: [{ type: "text", text: JSON.stringify(items) }] };
-				},
-			}),
-		);
-	}
-
-	return tools;
-};
+})


### PR DESCRIPTION
## The problem
Having a tool per collection can cause issues with MCP clients that have hard limits of number of tools available (i.e Cursor), with Directus installs with many collections.

<img width="906" alt="Screenshot 2025-04-08 at 12 51 44" src="https://github.com/user-attachments/assets/2135c0b7-b123-4bc5-a853-35da638e4bc6" />

Additionally, when there are many junction tables for many to many relationships, the combined server and tool name length can easily exceed 60 characters

<img width="860" alt="Screenshot 2025-04-08 at 12 52 39" src="https://github.com/user-attachments/assets/d8b79a83-dbf3-4e0c-8f5a-e5c149f39f99" />

## Suggested solution
As an alternative, we can have a single tool to read items from any collection.

Here's how the updated tool list looks like in Cursor:
<img width="942" alt="Screenshot 2025-04-08 at 12 54 46" src="https://github.com/user-attachments/assets/8ac44b53-14c1-4224-b83c-4e0e3dc4d39c" />
